### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Following providers and products are listed in alphabetical order.
 - [Railway](https://railway.app/)
 - [Render](https://render.com)
 - [Supabase.io](https://github.com/supabase/supabase)
+- [TinyStacks](https://www.tinystacks.com/)
 - [Zimki](https://www.slideshare.net/swardley/zimki-2006) - one of the original platform as a service offerings from Canon.
 
 #### Jamstack


### PR DESCRIPTION
Added TinyStacks into the PaaS section. Applications run directly on AWS vs in a PaaS' vendor's infrastructure or on a Kubernetes cluster deployed by most of the self-hosted or emulated vendors - so hopefully that's the right place. Thanks for maintaining this list.