### PR TITLE
Added TinyFunction to the Paas or Caas section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Following providers and products are listed in alphabetical order.
 - [Railway](https://railway.app/)
 - [Render](https://render.com)
 - [Supabase.io](https://github.com/supabase/supabase)
+- [TinyFunction](https://www.tinyfunction.com/)
 - [TinyStacks](https://www.tinystacks.com/)
 - [Zimki](https://www.slideshare.net/swardley/zimki-2006) - one of the original platform as a service offerings from Canon.
 


### PR DESCRIPTION
Added TinyFunction.com, an in browser aws function deployer to the list.