### PR TITLE
feat: Added Otomi to self-hosted PaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Following providers and products are listed in alphabetical order.
 - [Northflank](https://northflank.com/)
 - [Openfaas](https://www.openfaas.com/)
 - [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)
+- [Otomi](https://otomi.io/)
 - [Piku]( https://github.com/piku/piku)
 - [Porter](https://porter.run)
 - [PowerTools](https://www.powertools.dev/)


### PR DESCRIPTION
- Adding our open-source project [Otomi: Self-hosted PaaS for K8s](https://github.com/redkubes/otomi-core) to the repo.