### PR TITLE
Add Uncloud to self-hosted PaaS or PaaS emulated

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Following providers and products are listed in alphabetical order.
 - [Spaceship](https://spaceship.run)
 - [Stacksnap](https://klo.dev/stacksnap)
 - [TrueFoundry](https://truefoundry.com)
+- [Uncloud](https://uncloud.run)
 - [VMware Tanzu](https://tanzu.vmware.com)
 - [Zeabur](https://zeabur.com)
 - [Zeet](https://zeet.co)


### PR DESCRIPTION
Would love to include uncloud.run in the self-hosted list