### PR TITLE
fix: markdown formatting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Following providers and products are listed in alphabetical order.
 - [Google Cloud Run](https://cloud.google.com/run)
 - [Koyeb](https://www.koyeb.com)
 - [MicroCloud](https://canonical.com/microcloud)
-- [platformOS]([https://platformos.com]
+- [platformOS](https://platformos.com)
 - [Platform.sh](https://platform.sh)
 - [Ploi](https://ploi.io)
 - [Railway](https://railway.app/)


### PR DESCRIPTION
whopse - GitHub has changed brackets after pasting URL, I didn't fix it properly the first time, sorry! 