### PR TITLE
Add Diploi

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Following providers and products are listed in alphabetical order.
 - [Coherence](https://www.withcoherence.com/?ref=awesome-paas) in your own AWS or GCP account. 
 - [Cyclic](https://www.cyclic.sh/)
 - [Digitalocean App Platform](https://www.digitalocean.com/products/app-platform)
+- [Diploi](https://diploi.com/)
 - [Back4app Web Deployment](https://www.back4app.com/web-deployment-platform) 
 - [dotCloud](https://www.docker.com/docker-news-and-press/dotcloud-inc-now-docker-inc)
 - [Flightcontrol](https://www.flightcontrol.dev?ref=awesome-paas)


### PR DESCRIPTION
Diploi is a PaaS/CaaS service for developing and hosting web applications.
It would fit in the "PaaS or CaaS" and "Cloud IDE or Developer Workspaces" categories, but I only added it to the "PaaS or CaaS" one. If duplicated entries are allowed I can add it to the "Cloud IDE or Developer Workspaces" one too.