### PR TITLE
Add InstaPods to PaaS or CaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Following providers and products are listed in alphabetical order.
 - [Flightcontrol](https://www.flightcontrol.dev?ref=awesome-paas)
 - [Fly.io](https://fly.io)
 - [Heroku](https://www.heroku.com) - acquired by Salesforce.
+- [InstaPods](https://instapods.com)
 - [Google Cloud AppEngine](https://cloud.google.com/appengine)
 - [Google Cloud Run](https://cloud.google.com/run)
 - [Koyeb](https://www.koyeb.com)


### PR DESCRIPTION
Adding [InstaPods](https://instapods.com) to the PaaS or CaaS list.

InstaPods is a persistent pods platform with SSH access, starting at $3/mo. Supports Node.js, Python, PHP, and static sites with automatic SSL and domains.