### PR TITLE
Add AZIN — BYOC deployment platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Following providers and products are listed in alphabetical order.
 - [Aptible](https://aptible.com)
 - [AWS App Runner](https://aws.amazon.com/apprunner)
 - [AWS ECS](https://aws.amazon.com/ecs)
+- [AZIN](https://azin.run) - BYOC deployment platform. Push code, deploy to your own GCP account (AWS and Azure on roadmap). Zero Kubernetes config required.
 - [Backery](https://backery.io/)
 - [Clever Cloud](https://www.clever-cloud.com/)
 - [Cloud 66](https://www.cloud66.com/) on your own cloud or server. 


### PR DESCRIPTION
Adds [AZIN](https://azin.run) to the PaaS or CaaS section.

**What it is:** AZIN is a BYOC (Bring Your Own Cloud) deployment platform. You push code, AZIN deploys it to your own GCP account on GKE Autopilot. AWS and Azure support is on the roadmap.

**Why it belongs here:** AZIN sits between managed PaaS (Railway, Render) and self-hosted PaaS (Porter, Qovery). You get a push-to-deploy experience without managing Kubernetes, but your workloads run in your own cloud account.

- Auto-detects language/framework via Railpack (open-source builder)
- Provisions databases (Cloud SQL), caches (Memorystore), and load balancers in your VPC
- Git-push deploys, preview environments, autoscaling