### PR TITLE
Add SnapDeploy to PaaS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Following providers and products are listed in alphabetical order.
 - [Railway](https://railway.app/)
 - [Render](https://render.com)
 - [Sliplane.io](https://sliplane.io)
+- [SnapDeploy](https://snapdeploy.dev) - Docker-native container hosting with auto-sleep/wake, GitHub auto-deploy, framework detection, managed databases, and free tier.
 - [Supabase.io](https://github.com/supabase/supabase)
 - [TinyFunction](https://www.tinyfunction.com/)
 - [TinyStacks](https://www.tinystacks.com/)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Following providers and products are listed in alphabetical order.
 - [Railway](https://railway.app/)
 - [Render](https://render.com)
 - [Sliplane.io](https://sliplane.io)
-- [SnapDeploy](https://snapdeploy.dev) - Docker-native container hosting with auto-sleep/wake, GitHub auto-deploy, framework detection, managed databases, and free tier.
+- [SnapDeploy](https://snapdeploy.dev) Deploy for free, pay only when you need always on.
 - [Supabase.io](https://github.com/supabase/supabase)
 - [TinyFunction](https://www.tinyfunction.com/)
 - [TinyStacks](https://www.tinystacks.com/)


### PR DESCRIPTION
Adding SnapDeploy to the PaaS/CaaS section.

SnapDeploy is a Docker-native container hosting platform:
- Free tier: up to 4 containers, 512 MB RAM, 0.25 vCPU each, no time limits
- Auto-sleep after idle, auto-wake on traffic
- GitHub auto-deploy on push
- Framework auto-detection (Node.js, Python, Java, Go, PHP, Ruby, .NET)
- Managed database add-ons (PostgreSQL, MySQL, MariaDB, MongoDB)
- Always-On from $12/mo per container

I use SnapDeploy daily (I'm the founder & developer).

Website: https://snapdeploy.dev
GitHub Marketplace: https://github.com/marketplace/snapdeploy-app
