### PR TITLE
Add Qovery to PaaS or CaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Following providers and products are listed in alphabetical order.
 - [platformOS](https://platformos.com)
 - [Platform.sh](https://platform.sh)
 - [Ploi](https://ploi.io)
+- [Qovery](https://www.qovery.com/) - Enterprise Kubernetes management platform. Deploy applications, databases, Helm charts, and Terraform modules on AWS EKS, GCP GKE, Azure AKS, and Scaleway. Cost-efficient GPU scheduling for AI/ML workloads. Includes [Terraform provider](https://registry.terraform.io/providers/Qovery/qovery/latest/docs), CLI, API, [MCP Server](https://mcp.qovery.com/mcp), and [AI Agent Skill](https://github.com/Qovery/qovery-skills).
 - [Railway](https://railway.app/)
 - [Render](https://render.com)
 - [Sliplane.io](https://sliplane.io)


### PR DESCRIPTION
Adds [Qovery](https://www.qovery.com) — enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS EKS, GCP GKE, Azure AKS, and Scaleway. Cost-efficient GPU scheduling for AI/ML workloads. Includes Terraform provider, CLI, REST API, AI Agent Skill and MCP Server.

- Website: https://www.qovery.com
- GitHub: https://github.com/Qovery
- AI Agent Skill: https://github.com/Qovery/qovery-skills
- MCP Server: https://mcp.qovery.com/mcp