### PR TITLE
Add France Nuage to PaaS or CaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Following providers and products are listed in alphabetical order.
 - [dotCloud](https://www.docker.com/docker-news-and-press/dotcloud-inc-now-docker-inc)
 - [Flightcontrol](https://www.flightcontrol.dev?ref=awesome-paas)
 - [Fly.io](https://fly.io)
+- [France Nuage](https://france-nuage.fr) - Sovereign open-source cloud (SSPL-1.0) hosted 100% in France; managed hosting of open-source apps (Grafana, Matomo, Odoo...) and S3 object storage.
 - [Heroku](https://www.heroku.com) - acquired by Salesforce.
 - [InstaPods](https://instapods.com)
 - [Google Cloud AppEngine](https://cloud.google.com/appengine)


### PR DESCRIPTION
## Summary

- Adds [France Nuage](https://france-nuage.fr) to the PaaS or CaaS section
- France Nuage is a sovereign open-source cloud platform hosted 100% in France
- Provides managed hosting of open-source applications (Grafana, Matomo, Odoo, Metabase, etc.) and S3 object storage
- Source code: https://github.com/France-Nuage/plateforme (SSPL-1.0)