### PR TITLE
Add Ownkube to PaaS or CaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Following providers and products are listed in alphabetical order.
 - [Google Cloud Run](https://cloud.google.com/run)
 - [Koyeb](https://www.koyeb.com)
 - [MicroCloud](https://canonical.com/microcloud)
+- [Ownkube](https://ownkube.io) in your own AWS account on k3s or EKS.
 - [platformOS](https://platformos.com)
 - [Platform.sh](https://platform.sh)
 - [Ploi](https://ploi.io)


### PR DESCRIPTION
Adds [Ownkube](https://ownkube.io) under **PaaS or CaaS**, alphabetically between MicroCloud and platformOS.

Ownkube is a PaaS that runs in the user's own AWS account on top of k3s (single-node) or EKS (multi-node). Same BYOC framing as Coherence (already listed). Free for teams on single-node k3s; usage-based on EKS multi-node.

- One link added
- Alphabetical placement preserved
- No duplicate