### PR TITLE
Add Zerops to PaaS or CaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Following providers and products are listed in alphabetical order.
 - [TinyStacks](https://www.tinystacks.com/) `defunct` — domain listed for sale; project no longer operating.
 - [Upsun (formerly Platform.sh)](https://platform.sh) `alive` — highly flexible PaaS with predictable pricing and self-service resources.
 - [Zeabur](https://zeabur.com) `alive` — AI DevOps engineer; an agent that runs your infrastructure while AI writes your code.
+- [Zerops](https://zerops.io) `alive` — bare-metal developer cloud with full Linux containers, hardware-only pricing, and managed databases on project-private networking.
 - [Zimki](https://www.slideshare.net/swardley/zimki-2006) `defunct` — historical; one of the original platform-as-a-service offerings, from Canon.
 
 #### Sandboxes and Harnesses


### PR DESCRIPTION
Zerops is a developer cloud built on bare metal with full Linux system containers, hardware-only pricing (no plans, no seats — pay for the hardware you use), and managed databases (Postgres, MariaDB, Valkey, Kafka, and others) on project-private networking. It's been live since 2020.

https://zerops.io