### PR TITLE
Add ApexWeave to PaaS or CaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Following providers and products are listed in alphabetical order.
 
 #### PaaS or CaaS
 - [Acquia Cloud](https://www.acquia.com) `alive` — Drupal-focused cloud platform for digital experiences.
+- [ApexWeave](https://apexweave.com) `alive` — Heroku-style PaaS with git push deploys, managed databases, and WordPress hosting; 14-day free trial, no credit card required.
 - [Appliku](https://appliku.com) `alive` — modern application deployment platform; deploy unlimited apps and databases for one monthly price via git push.
 - [apply.build](https://apply.build) `alive` — European PaaS with WAF, vulnerability scanning, metrics, and logs included in every plan.
 - [Aptible](https://aptible.com) `alive` — secure, HITRUST R2 certified cloud infrastructure for digital health teams.


### PR DESCRIPTION
Adds ApexWeave, a Heroku-style PaaS with git push deploys, managed databases, and WordPress hosting, with a genuine 14-day free trial and no credit card required. Placed alphabetically between Acquia Cloud and Appliku.