### PR TITLE
Add Orbit (Git-to-Flux PaaS) to PaaS or CaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Following providers and products are listed in alphabetical order.
 - [Linode (Akamai Cloud)](https://www.linode.com) `alive` — Akamai's developer cloud with managed Kubernetes, databases, and compute.
 - [MicroCloud](https://canonical.com/microcloud) `alive` — Canonical's lightweight, automated open source cloud platform.
 - [Mogenius](https://mogenius.com) `alive` — cloud-native development platform built on Kubernetes.
+- [Orbit](https://orbit.runonflux.com) `alive` — deploy any Git repo to the Flux decentralized cloud; git push-to-deploy with Nixpacks framework detection, no single point of failure, no egress fees, and a free-forever tier (paid from $0.99/mo)
 - [Ownkube](https://ownkube.io) `alive` — developer platform in your own AWS account on k3s or EKS; named agents (Cost, Incident, Scaling, Security) run your ops.
 - [platformOS](https://platformos.com) `alive` — fully managed PaaS with no vendor lock-in or hidden fees.
 - [Ploi](https://ploi.io) `alive` — server management and site deployment tool.


### PR DESCRIPTION
Adds Orbit — a Git-to-Flux PaaS that deploys any repository to the Flux  decentralized cloud (git push-to-deploy, Nixpacks framework detection, no  single point of failure, no egress fees, free-forever tier, paid from $0.99/mo).