### PR TITLE
Add Granite to PaaS or CaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Following providers and products are listed in alphabetical order.
 - [Genezio](https://genezio.com) `alive` — full-stack development platform with type-safe client/server communication.
 - [Google Cloud AppEngine](https://cloud.google.com/appengine) `alive` — fully managed serverless platform for web and mobile backends.
 - [Google Cloud Run](https://cloud.google.com/run) `alive` — fully managed platform for containerized apps in any language.
+- [Granite](https://granite.so) `alive` — deploy apps, managed databases, and S3-compatible storage from source or Docker images; built-in container registry and unlimited team seats on every plan; formerly NoVPS, from $9/mo.
 - [Heroku](https://www.heroku.com) `alive` — original cloud application platform, acquired by Salesforce.
 - [IBM Cloud Code Engine](https://cloud.ibm.com/codeengine) `alive` — fully managed serverless platform on IBM Cloud.
 - [InstaPods](https://instapods.com) `alive` — one-command deploys for AI-built apps; $3/mo after 7-day free trial.


### PR DESCRIPTION
Adds [Granite](https://granite.so) to the **PaaS or CaaS** section.

Granite is a PaaS for deploying apps, managed databases (PostgreSQL, MySQL, MongoDB-compatible), and S3-compatible storage from source (GitHub/GitLab/Bitbucket) or Docker images, with a built-in container registry. Plans start at $9/mo and include unlimited workspace seats.

**Disclosure:** I work on Granite — submitting per the "if you think your (favorite) service is not listed here, feel free to create a pull-request" note in the README. Happy to adjust the wording or drop the entry if it isn't a fit.

Note: the platform was previously listed elsewhere as NoVPS (novps.io); it was renamed to Granite in June 2026 and novps.io now redirects to granite.so. I mentioned the former name in the entry for continuity — glad to remove it if you'd rather keep entries brand-only.

Checklist against CONTRIBUTING.md:
- [x] Sorted alphabetically (between `Google Cloud Run` and `Heroku`)
- [x] One link per item
- [x] The link is the name of the service
- [x] Existing category, no new category added
- [x] Tagged `alive` per the Status convention