### PR TITLE
Add harvis.dev to Jamstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Following providers and products are listed in alphabetical order.
 - [Github Pages](https://pages.github.com/) `alive` — static site hosting directly from your GitHub repository.
 - [GitLab Pages](https://docs.gitlab.com/ee/user/project/pages/) `alive` — static site hosting integrated into GitLab.
 - [Glitch](https://glitch.com/) `defunct` — collaborative web app builder; web hosting is being phased out (see [announcement](https://blog.glitch.com/post/changes-are-coming-to-glitch/)).
+- [harvis.dev](https://harvis.dev) `alive` — static hosting in one command; uploads a folder as-is and returns a live URL in seconds with no account, config, or build step. Also deployable from the browser, an HTTP API, a GitHub Action, or an AI agent over MCP.
 - [layer0](https://www.layer0.co) `defunct` — site offline; rebranded to Edgio, which itself was later acquired and wound down.
 - [Netlify](https://www.netlify.com) `alive` — Jamstack platform for production-ready web infrastructure with AI and code workflows. (Now also home to the former Gatsby Cloud.)
 - [Surge.sh](https://surge.sh) `alive` — static publishing for front-end developers; one-command deploys.


### PR DESCRIPTION
Adds [harvis.dev](https://harvis.dev) to the **Jamstack** section.

harvis.dev is static hosting for a folder of files: `npx harvis` uploads the folder as-is and prints a live URL in a couple of seconds — no account, no config file, no build step. Running it again updates the same site. The same deploy is available from a browser drag-and-drop, an HTTP API, a GitHub Action, and an MCP server for AI agents. Sites are served from Cloudflare's edge network.

It sits alongside Surge.sh and GitHub Pages in scope, so Jamstack seemed like the right section rather than PaaS or CaaS.

Checklist against CONTRIBUTING.md:

- [x] Sorted alphabetically — placed between `Glitch` and `layer0`
- [x] One link, and the link is the name of the service
- [x] Added to an existing category, so the 3-item rule for new categories doesn't apply
- [x] Tagged `alive`, matching the status convention in the README

Disclosure: I work on harvis.dev, so this is a self-submission — happy to adjust the wording, the tagline length, or the section if you'd rather it sat elsewhere.