### PR TITLE
Add intentic (self-hosted agent developer workspace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Following providers and products are listed in alphabetical order.
 - [Eclipse Che](https://www.eclipse.org/che/) `alive` — Kubernetes-native cloud IDE.
 - [Encore](https://encore.dev/) `alive` — open-source TypeScript backend framework with automated infrastructure.
 - [GitHub Codespaces](https://github.com/features/codespaces) `alive` — instant cloud-powered dev environments from GitHub.
+- [intentic](https://intentic.dev/) `alive` — self-hosted agent workspace; each coding agent gets its own container and git worktree on your own hardware, driven from any browser.
 - [Ona (formerly Gitpod)](https://www.gitpod.io/) `alive` — orchestrated background AI software engineers in the cloud.
 - [Okteto](https://okteto.com/) `alive` — fast, flexible Kubernetes development environments.
 - [Paizacloud](https://paiza.cloud/en/jupyter-notebook-online) `alive` — browser-based web development environment.


### PR DESCRIPTION
Adds **intentic** to *Cloud IDE or Developer Workspaces*, placed alphabetically between GitHub Codespaces
and Ona.

It is a developer workspace you host yourself: a browser IDE (file tree, editor, terminals that survive
disconnects, live preview) where the work is done by coding agents, each in its own container and git worktree
on your own hardware rather than a vendor's cloud. Sits closest to Coder.com and Ona on this list, on the
self-hosted side.

Open source (MIT, TypeScript), free, actively released.

Guidelines followed: one link per item, sorted alphabetically, single entry.

Disclosure: I maintain intentic.
