### PR TITLE
Add DormHost to PaaS or CaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Following providers and products are listed in alphabetical order.
 - [DigitalOcean Functions](https://www.digitalocean.com/products/functions) `alive` — DigitalOcean's serverless functions platform.
 - [Diploi](https://diploi.com/) `alive` — cloud development environments with one-click hosting; no manual server configuration.
 - [Darkmoon](https://github.com/ASCIT31/Dark-Moon) `alive` — open source autonomous pentest engine (GPL-3.0): AD + Kubernetes + web, evidence trail on every finding, runs on local or hosted models.
+- [DormHost](https://dormhost.dev) `alive` — Heroku-style git push deploys for student and hobby projects; Node.js, Python, Go, Java, Ruby, PHP, .NET, or a Dockerfile, with MongoDB/PostgreSQL/MariaDB on the same machine; ₹99/mo (~$1.15), 7-day free trial, sleeps when idle and wakes in ~200ms.
 - [dotCloud](https://www.docker.com/docker-news-and-press/dotcloud-inc-now-docker-inc) `defunct` — historical; dotCloud became Docker, Inc.
 - [Engine Yard](https://www.engineyard.com) `alive` — managed cloud platform for Ruby on Rails and modern web apps.
 - [Flightcontrol](https://www.flightcontrol.dev?ref=awesome-paas) `alive` — PaaS that deploys directly to your own AWS account; no black box, lock-in, or AWS markups.


### PR DESCRIPTION
Adding DormHost (https://dormhost.dev), a git-push PaaS aimed at student and hobby projects: Node.js, Python, Go, Java, Ruby, PHP, .NET or a Dockerfile, with MongoDB/PostgreSQL/MariaDB on the same machine as the app, HTTPS, and a 7-day free trial. Priced at ₹99/mo (~$1.15), with a Nap tier that sleeps when idle and wakes in ~200ms and an Awake tier that stays running for bots and workers.

Placed alphabetically in the PaaS or CaaS section, one link, matches the existing entry format.

Disclosure: I'm the operator.