### PR TITLE
Add OpenRun to Self-Hosted PaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Following providers and products are listed in alphabetical order.
 - [Linx](https://linx.software) `alive` — low-code iPaaS platform for integration, API development, and business process automation.
 - [Northflank](https://northflank.com/) `alive` — developer platform for deploying any project, on Northflank's cloud or yours.
 - [Openfaas](https://www.openfaas.com/) `alive` — serverless functions made simple with Kubernetes.
+- [OpenRun](https://openrun.dev/) `alive` — open source deployment platform for internal tools; deploy web apps declaratively on a single node or Kubernetes, with OIDC/SAML auth and RBAC.
 - [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift) `alive` — Red Hat's unified application development platform for hybrid cloud.
 - [Piku](https://github.com/piku/piku) `alive` — the tiniest PaaS you've ever seen; git push deployments to your own servers.
 - [Plural](https://www.plural.sh) `alive` — open-source platform for deploying applications on Kubernetes.


### PR DESCRIPTION
Adds [OpenRun](https://openrun.dev/) to the **Self-Hosted PaaS or PaaS emulated** section.

OpenRun ([GitHub](https://github.com/openrundev/openrun)) is an open source (Apache-2.0) deployment platform for teams to deploy internal tools. Web apps are deployed declaratively, on a single node or on Kubernetes, with OIDC/SAML auth and RBAC built in.

**Disclosure:** I work on OpenRun. Submitting per the "if you think your (favorite) service is not listed here, feel free to create a pull-request" note in the README. Happy to adjust the wording if needed.

Checklist against CONTRIBUTING.md:
- [x] Sorted alphabetically (between `Openfaas` and `Openshift`)
- [x] One link per item
- [x] The link is the name of the project
- [x] Existing category, no new category added
- [x] Tagged `alive` per the Status convention