### PR TITLE
Add Temps to Self-Hosted PaaS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Following providers and products are listed in alphabetical order.
 - [Spacecloud](https://space-cloud.io/) `alive` — instant realtime APIs for serverless apps.
 - [Spaceship / Shipmate](https://spaceship.run) `alive` — one-click code launcher.
 - [Stacksnap](https://klo.dev/stacksnap) `defunct` — page returns 404 on klo.dev.
+- [Temps](https://temps.sh) `alive` — self-hosted PaaS bundling deploys, analytics, error tracking and session replay in one Rust binary.
 - [TrueFoundry](https://truefoundry.com) `alive` — enterprise-grade AI Gateway combining LLM, MCP, and Agent Gateways.
 - [Uncloud](https://uncloud.run) `alive` — production self-hosting for Docker Compose apps without Kubernetes complexity.
 - [VMware Tanzu](https://tanzu.vmware.com) `alive` — VMware's enterprise PaaS for accelerating ideas to production.


### PR DESCRIPTION
Temps (https://github.com/gotempsh/temps) is a self-hosted PaaS in the same category as Coolify/Dokploy/CapRover — git-push deploys plus built-in web analytics, Sentry-compatible error tracking, session replay and uptime monitoring in one Rust binary. MIT / Apache-2.0, 640+ GitHub stars.