### PR TITLE
Add Appaloft (open-source Railway alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Following providers and products are listed in alphabetical order.
 
 #### Self-Hosted PaaS or PaaS emulated
 - [Akamai App Platform (formerly Otomi)](https://otomi.io/) `alive` — Kubernetes app platform; now part of Akamai.
+- [Appaloft](https://github.com/appaloft/appaloft) `alive` — open-source Railway alternative: deploy a folder to a URL with `appaloft up` (git optional) on servers you control, plus `appaloft setup agent` for Cursor/OpenCode.
 - [Argonaut](https://argonaut.dev/) `defunct` — argonaut.dev now serves WarpBuild; the original Argonaut platform is no longer operating.
 - [Azure Krustlet](https://krustlet.dev/) `defunct` — Kubernetes Kubelet in Rust for running WebAssembly modules; the README states the project is no longer actively maintained and maintainers have moved on (last commit Oct 2023).
 - [BoltOps](https://www.boltops.com/) `alive` — DevOps-as-a-service.


### PR DESCRIPTION
Adds [Appaloft](https://github.com/appaloft/appaloft) (Apache-2.0) under **Self-Hosted PaaS or PaaS emulated**, alphabetically between Akamai App Platform and Argonaut.

Appaloft is an open-source Railway alternative: `appaloft up` deploys a local folder to a live URL (git optional) on servers you control, and `appaloft setup agent` configures Cursor/OpenCode.